### PR TITLE
Add kimi k2

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,9 +199,9 @@ hf.co/Mungert/Fin-R1-GGUF:latest    5050b9253527    4.7 GB    22 seconds ago
     insert        
 ```
 
-#### 5. OpenRouter setup (Optional - for Grok-4)
+#### 5. OpenRouter setup (Optional - for Grok-4, Kimi-K2)
 
-If you want to use OpenRouter's Grok-4 instead of local models, follow these steps:
+If you want to use OpenRouter's Grok-4 or Kimi-K2 instead of local models, follow these steps:
 
 **Sign up for OpenRouter**
 1. Visit [https://openrouter.ai/](https://openrouter.ai/) and create an account
@@ -211,7 +211,7 @@ If you want to use OpenRouter's Grok-4 instead of local models, follow these ste
 **Configure the trading agent**
 1. Edit `config.py` and make these changes:
    ```python
-   MODEL_KEY = "grok4"  # Change from "qwen3b" to "grok4"
+   MODEL_KEY = "grok4"  # Change from "qwen3b" to "grok4" or "kimi-k2"
    OPENROUTER_API_KEY = "your_actual_api_key_here"  # Replace with your real API key
    ```
 

--- a/config.py
+++ b/config.py
@@ -63,11 +63,16 @@ AVAILABLE_MODELS = {
         'context_capacity': 256000,  # See https://openrouter.ai/x-ai/grok-4
         'provider': 'openrouter'
     },
+    'kimi-k2': {
+        'model': 'moonshotai/kimi-k2:free', # See https://openrouter.ai/moonshotai/kimi-k2:free
+        'context_capacity': 65536,  # See https://openrouter.ai/moonshotai/kimi-k2:free
+        'provider': 'openrouter'
+    },
 }
 
 # Model key from AVAILABLE_MODELS to be used with the agent
 # Use "grok4" for OpenRouter's Grok-4, "qwen3b" for local Ollama, etc.
-MODEL_KEY = "grok4"
+MODEL_KEY = "kimi-k2"
 
 OLLAMA_MODEL = AVAILABLE_MODELS[MODEL_KEY]['model']
 OLLAMA_URL = "http://localhost:11434"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to include setup instructions and configuration examples for the "Kimi-K2" model alongside "Grok-4" when using OpenRouter.

* **New Features**
  * Added support for the "Kimi-K2" model, making it available as a selectable option.

* **Chores**
  * Changed the default model from "Grok-4" to "Kimi-K2".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->